### PR TITLE
fix

### DIFF
--- a/controllers/admin/AdminSupplyOrdersController.php
+++ b/controllers/admin/AdminSupplyOrdersController.php
@@ -1450,11 +1450,11 @@ class AdminSupplyOrdersControllerCore extends AdminController
                     // converts the unit price to the warehouse currency if needed
                     if ($supply_order->id_currency != $warehouse->id_currency) {
                         // first, converts the price to the default currency
-                        $price_converted_to_default_currency = Tools::convertPrice($supply_order_detail->unit_price_te,
+                        $price_converted_to_default_currency = Tools::convertPrice($price,
                             $supply_order->id_currency, false);
 
                         // then, converts the newly calculated pri-ce from the default currency to the needed currency
-                        $price = (float) Tools::ps_round(Tools::convertPrice($price_converted_to_default_currency,
+                        $price = Tools::ps_round(Tools::convertPrice($price_converted_to_default_currency,
                             $warehouse->id_currency, true), 6);
                     }
 


### PR DESCRIPTION
Tools::convertPrice expects a float ad first parameter.
as you suggested, the first (float) cast solves the problem. the second one, the one inside the if sttement, uses $price_converted_to_default_currency, wich comes from the previous line as the output of another convertPrice. The input of that convertPrice is, again not casted version of $supply_order_detail->unit_price_te
With this changes we can suppouse that when reaching second assignment of $price there will be a correct value as we can rely on convertPrice to output a safe value if the input is float.
